### PR TITLE
filter-list to dropdown conversion script

### DIFF
--- a/Javascript/dropdowns/list_to_dropdown.js
+++ b/Javascript/dropdowns/list_to_dropdown.js
@@ -1,0 +1,41 @@
+/*============================================
+ *
+ *               mcmsFilterSelect()
+ *
+ *=============================================
+ *
+ * Sets up select menus for long sidebar lists.
+ * Demo: mcmsFilterSelect('#sermon_list_archive');
+ *
+ */ 
+function mcmsFilterSelect(list){
+    
+    $(list).each(function(){
+        var    ul = $(this),
+                id = ul.attr('id'),
+                items = $('li', this),
+                select = '',
+                select_options = '';
+        items.each(function(i){
+            var    a = $('> a', this),
+                    title = a.text(),
+                    url = a.attr('href');
+            var option = '<option value="'+url+'">'+title+'</option>';
+            select_options = select_options + option;
+            if (!--items.length){
+                select = select + '<p>';
+                select = select + '<select id="select_'+id+'" style="width:140px;">';
+                select = select + '<option value="">-</option>';
+                select = select + select_options;
+                select = select + '</select></div>';
+                select = select + '</p>';
+                ul.replaceWith(select);
+                $('body').on('change', '#select_' + id, function(){
+                    window.location.href = $(this).val();
+                });
+            }
+        });
+        
+    });
+    
+}

--- a/Reftagger/Readme.md
+++ b/Reftagger/Readme.md
@@ -1,5 +1,13 @@
 # Instructions for using Reftagger on Require.js sites
 
+## Basic Instructions
+
+1. Follow the steps located at [https://github.com/MonkDev/monkcms-snippets/blob/master/Reftagger/reftagger-and-require.js](https://github.com/MonkDev/monkcms-snippets/blob/master/Reftagger/reftagger-and-require.js) to update the javascript related files.
+2. Change all instances of `__passage__` and `__passagelink__` in the **sermon layouts** as well as **ekk_sermonpage.php** with `__passagebook__ __passageverse__`.
+3. Go to *CMS - Site Config > Account* and uncheck the box next to **BIBLE CLOUD _Integrate with Biblecloud.com_**
+4. Clear the site cache
+5. Test
+
 http://reftagger.com/
 http://requirejs.org
 


### PR DESCRIPTION
This script is used to convert long lists (generally filters) into dropdown menus.

Original code from @chrisullyott