### PR TITLE
Add helpful note on sermon feed

### DIFF
--- a/BlueBridge/json_sermons.php
+++ b/BlueBridge/json_sermons.php
@@ -7,7 +7,7 @@ $json;
 $category = "";
 $series = "";
 $group = "";
-$howmany = "";
+$howmany = ""; // if left blank the API will return 50
 $offset = "";
 $order = "recent";
 $hideseries="";


### PR DESCRIPTION
Added a comment to let people know that if the $howmany variable is left blank, the API will only return the latest 50 records.