### PR TITLE
update feed to include offset and total info & documentation

### DIFF
--- a/BlueBridge/README.md
+++ b/BlueBridge/README.md
@@ -1,15 +1,38 @@
-# Bluebridge app integrations
-
-http://gobluebridge.com/
+# [Bluebridge](http://gobluebridge.com) app integrations
 
 ---
 
 ### Sermons
 
-json_sermons.php
+*json_sermons.php*
+
+The following filters and query parameters can be used to manipulate the sermons feed
+
+- `?series=some-series-slug`
+- `?category=comma,separated,category-slugs,no-spaces`
+- `?group=group-slug`
+- `?limit=12` (how many do you want displayed)
+- `?order=recent` (recent, oldest, preacher, series, series-title, category, title)
+- `?hide_series=series-slug`
+- `?hide_category=category-slugs`
+- `?hide_group=group-slug`
+- `?preacher=preacher-slug`
+- `?tags=keyword-slugs`
+- `?passage=passage-slug`
+- `?offset=12` (used to paginate through results)
+
+Query parameters can be changed by by replacing subsequent ? with &.
+For example `json_sermons.php?offset=12&limit=12&order=oldest`
+
+If no parameters are added, we will default to show the most recent 50 sermons.
 
 ### Events
 
-json_events.php
+*json_events.php*
 
-json_events_custom.php
+*json\_events\_custom.php*
+
+---
+
+### Questions?
+contact [support@monkdevelopment.com](mailto:support@monkdevelopment.com)

--- a/BlueBridge/json_sermons.php
+++ b/BlueBridge/json_sermons.php
@@ -57,7 +57,7 @@ if($filters != null){
 		case 'passage':
 			$passage = $value;
 			break;
-		case 'start':
+		case 'offset':
 			$offset = $value;
 			break;
 
@@ -216,10 +216,14 @@ $totalpossible = getContent(
 );
 
 
+
 $output = array(
 	items => $nodes,
-	total => intval($totalpossible)
+	sermonsReturned => $i,
+	totalSermons => intval($totalpossible),
+	currentOffset => $offset ? $offset : 0
 );
+
 
 //$output = array("items" => $nodes);
 


### PR DESCRIPTION
This adds documentation to what can be manipulated with the JSON Sermons feed.

I also added some helpful info if `offsets` or  `howmany` are being used.