### PR TITLE
Add number of files downloaded to end message

### DIFF
--- a/monkCLI/src/commands/exportContainerCommand.php
+++ b/monkCLI/src/commands/exportContainerCommand.php
@@ -67,12 +67,11 @@ class exportContainerCommand extends monkCommand
 
         $files = $container->ObjectList();
         $numberOfFiles = $container->getObjectCount();
+        $filesDownloaded = 0;
         $this->message('Number of Files - '. $numberOfFiles .'.', $output);
         $progress = new ProgressBar($output, $numberOfFiles);
         $progress->start();
         ini_set('memory_limit', -1);
-
-        $filesDownloaded = 0;
         
         while ($object = $files->Next()) {
             $cloudFile_name = $object->getName();

--- a/monkCLI/src/commands/exportContainerCommand.php
+++ b/monkCLI/src/commands/exportContainerCommand.php
@@ -71,6 +71,8 @@ class exportContainerCommand extends monkCommand
         $progress = new ProgressBar($output, $numberOfFiles);
         $progress->start();
         ini_set('memory_limit', -1);
+
+        $filesDownloaded = 0;
         
         while ($object = $files->Next()) {
             $cloudFile_name = $object->getName();
@@ -144,11 +146,12 @@ class exportContainerCommand extends monkCommand
             } else {
                 // File has been saved
                 $this->message('<info>File successfully saved!</info>', $output);
+                $filesDownloaded++;
             }
         }
 
         $progress->finish();
-        $this->message('<info>Finished Downloading Files.</info>', $output, true);
+        $this->message('<info>Finished Downloading ' . $filesDownloaded . ' Files.</info>', $output, true);
 
         return $container;
     }


### PR DESCRIPTION
Add a count of the number of files that successfully downloaded to the ending message of the export

At the beginning of the export we list how many items are in the container, but it would be useful to at the end get a count of the files actually downloaded by the script.