### PR TITLE
Changed conditional

### DIFF
--- a/Alerts/readme.md
+++ b/Alerts/readme.md
@@ -87,7 +87,7 @@ $showAlert = trim(getContent(
 	"show:__customshowalertmessage__true",
 	"noecho"
 ));
-if ($showAlert == true){
+if ($showAlert == "true"){
 	getContent(
 		"section",
 		"display:detail",


### PR DESCRIPTION
The alert was showing up on event and sermon detail pages because of the $showAlert == true. Changed it to $showAlert == “true” because it should have been the string, not the boolean.