### PR TITLE
Unnecessary CSS

### DIFF
--- a/Alerts/readme.md
+++ b/Alerts/readme.md
@@ -35,9 +35,6 @@ Add this to the end of the file:
 
 ```
 /* ALERT MESSAGE BOX */
-	body.hasAlert {
-		padding-top: 42px; /* set to the height of #alert */
-	}
 	#alert {
 	    padding: 10px;
 		text-align: center;


### PR DESCRIPTION
Removed
body.hasAlert {
	padding-top: 42px; /* set to the height of #alert */
}
because it wasn’t necessary.