### PR TITLE
Fixed bug

### DIFF
--- a/Javascript/accordion/accordion.js
+++ b/Javascript/accordion/accordion.js
@@ -29,6 +29,7 @@ function accordion(triggerClass, contentClass, linked) {
 			var $this = $(this);
 			var $target = $this.next('.accordionbellow');
 			var $all = $('.accordionbellow');
+			$(triggerClass).removeClass('active');
 			$(this).toggleClass('active');
 			if (!$target.hasClass('active')) {
 				if (linked) {


### PR DESCRIPTION
When a trigger was clicked, it would add the ‘active’ class, but when another trigger was clicked, it would not remove the class from the previously selected trigger. This fixes it.